### PR TITLE
CTCP-1804: Add PATCH endpoint for updating the updated time on an association

### DIFF
--- a/app/uk/gov/hmrc/transitmovementspushnotifications/controllers/PushNotificationController.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/controllers/PushNotificationController.scala
@@ -26,6 +26,7 @@ import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.streams.Accumulator
 import play.api.mvc.Action
+import play.api.mvc.AnyContent
 import play.api.mvc.BodyParser
 import play.api.mvc.ControllerComponents
 import play.api.mvc.Result
@@ -65,6 +66,16 @@ class PushNotificationController @Inject() (
       } yield result).fold[Result](
         baseError => Status(baseError.code.statusCode)(Json.toJson(baseError)),
         _ => Accepted
+      )
+  }
+
+  def updateAssociationTTL(movementId: MovementId): Action[AnyContent] = Action.async {
+    boxAssociationRepository
+      .update(movementId)
+      .asPresentation
+      .fold(
+        baseError => Status(baseError.code.statusCode)(Json.toJson(baseError)),
+        _ => NoContent
       )
   }
 

--- a/app/uk/gov/hmrc/transitmovementspushnotifications/repositories/BoxAssociationRepository.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/repositories/BoxAssociationRepository.scala
@@ -47,6 +47,7 @@ import scala.util.control.NonFatal
 @ImplementedBy(classOf[BoxAssociationRepositoryImpl])
 trait BoxAssociationRepository {
   def insert(boxAssociation: BoxAssociation): EitherT[Future, MongoError, Unit]
+  def update(movementId: MovementId): EitherT[Future, MongoError, Unit]
   def getBoxAssociation(movementId: MovementId): EitherT[Future, MongoError, BoxAssociation]
 }
 
@@ -73,6 +74,8 @@ class BoxAssociationRepositoryImpl @Inject() (
     with BoxAssociationRepository
     with Logging
     with CommonFormats {
+
+  private def setUpdated = mSet("updated", OffsetDateTime.ofInstant(clock.instant, ZoneOffset.UTC))
 
   private def mongoRetry[A](func: Future[Either[MongoError, A]]): EitherT[Future, MongoError, A] =
     EitherT {
@@ -102,8 +105,22 @@ class BoxAssociationRepositoryImpl @Inject() (
         Future.successful(Left(UnexpectedError(Some(ex))))
     })
 
-  override def getBoxAssociation(movementId: MovementId): EitherT[Future, MongoError, BoxAssociation] = {
-    val setUpdated = mSet("updated", OffsetDateTime.ofInstant(clock.instant, ZoneOffset.UTC))
+  override def update(movementId: MovementId): EitherT[Future, MongoError, Unit] =
+    mongoRetry(Try(collection.updateOne(mEq(movementId), setUpdated).head()) match {
+      case Success(fUpdateResult) =>
+        fUpdateResult
+          .filter(_.getModifiedCount > 0)
+          .map(
+            _ => Right(())
+          )
+          .recover {
+            case _: NoSuchElementException => Left(DocumentNotFound(s"Could not find BoxAssociation with id: ${movementId.value}"))
+            case NonFatal(ex)              => Left(UnexpectedError(Some(ex)))
+          }
+      case Failure(ex) => Future.successful(Left(UnexpectedError(Some(ex))))
+    })
+
+  override def getBoxAssociation(movementId: MovementId): EitherT[Future, MongoError, BoxAssociation] =
     mongoRetry(Try(collection.findOneAndUpdate(mEq(movementId), setUpdated).headOption()) match {
       case Success(fOptBox) =>
         fOptBox.map {
@@ -112,6 +129,5 @@ class BoxAssociationRepositoryImpl @Inject() (
         }
       case Failure(ex) => Future.successful(Left(UnexpectedError(Some(ex))))
     })
-  }
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,5 +1,7 @@
 # microservice specific routes
 
-POST        /traders/movements/:movementId/box                      uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.createBoxAssociation(movementId: MovementId)
+POST       /traders/movements/:movementId/box                      uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.createBoxAssociation(movementId: MovementId)
+
+PATCH      /traders/movements/:movementId                          uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.updateAssociationTTL(movementId: MovementId)
 
 POST       /traders/movements/:movementId/messages/:messageId       uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.postNotification(movementId: MovementId, messageId: MessageId)


### PR DESCRIPTION
Endpoint `PATCH: /transit-movements-push-notifications/traders/movements/:movementId` with no body returns a 204 when successful, 404 when the association doesn't exist, and 500 in error cases, and updated the updated time to the current time, effectively resetting the TTL.