### PR TITLE
CTCP-3491, CTCP-3509: Add messageType and other IDs to push notifications

### DIFF
--- a/app/uk/gov/hmrc/transitmovementspushnotifications/models/Bindings.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/models/Bindings.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementspushnotifications.models
+
+import play.api.mvc.PathBindable
+
+object Bindings {
+
+  implicit val notificationTypeBinding: PathBindable[NotificationType] = new PathBindable[NotificationType] {
+
+    override def bind(key: String, value: String): Either[String, NotificationType] =
+      NotificationType.findByPathRepresentation(value).toRight(s"Unable to find notification type of $value")
+
+    override def unbind(key: String, value: NotificationType): String = value.pathRepresentation
+  }
+
+}

--- a/app/uk/gov/hmrc/transitmovementspushnotifications/models/MessageType.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/models/MessageType.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementspushnotifications.models
+
+import play.api.libs.json.Format
+import play.api.libs.json.Json
+
+object MessageType {
+  implicit val format: Format[MessageType] = Json.valueFormat
+}
+
+case class MessageType(value: String) extends AnyVal

--- a/app/uk/gov/hmrc/transitmovementspushnotifications/models/Notification.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/models/Notification.scala
@@ -23,7 +23,7 @@ sealed trait Notification extends Product with Serializable {
   val notificationType: NotificationType
 }
 
-case class MessageReceivedNotification(messageUri: String, messageBody: Option[String]) extends Notification {
+case class MessageReceivedNotification(messageUri: String, messageType: Option[MessageType], messageBody: Option[String]) extends Notification {
   override val notificationType: NotificationType = NotificationType.MESSAGE_RECEIVED
 }
 
@@ -45,9 +45,10 @@ object Notification {
   }
 
   implicit val notificationWrites: OWrites[Notification] = OWrites[Notification] {
-    case x: MessageReceivedNotification =>
-      Json.obj("messageUri" -> x.messageUri) ++ Json.obj("notificationType" -> x.notificationType) ++ Json.obj("messageBody" -> x.messageBody)
-    case x: SubmissionNotification =>
-      Json.obj("messageUri" -> x.messageUri) ++ Json.obj("notificationType" -> x.notificationType) ++ Json.obj("response" -> x.response)
+    notification =>
+      Json.obj("notificationType" -> notification.notificationType) ++ (notification match {
+        case x: MessageReceivedNotification => messageReceivedNotificationFormat.writes(x)
+        case x: SubmissionNotification      => submissionNotificationFormat.writes(x)
+      })
   }
 }

--- a/app/uk/gov/hmrc/transitmovementspushnotifications/models/NotificationType.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/models/NotificationType.scala
@@ -23,24 +23,30 @@ import play.api.libs.json.Json
 import play.api.libs.json.Reads
 import play.api.libs.json.Writes
 
-sealed trait NotificationType
+sealed trait NotificationType {
+  def pathRepresentation: String
+}
 
 object NotificationType {
-  final case object SUBMISSION_NOTIFICATION extends NotificationType
 
-  final case object MESSAGE_RECEIVED extends NotificationType
-
-  val values = Seq(SUBMISSION_NOTIFICATION, MESSAGE_RECEIVED)
-
-  implicit val notificationTypeWrites = new Writes[NotificationType] {
-
-    def writes(notificationType: NotificationType) = Json.toJson(notificationType.toString())
+  final case object SUBMISSION_NOTIFICATION extends NotificationType {
+    override def pathRepresentation: String = "submissionNotification"
   }
+
+  final case object MESSAGE_RECEIVED extends NotificationType {
+    override def pathRepresentation: String = "messageReceived"
+  }
+
+  val values: Seq[NotificationType] = Seq(SUBMISSION_NOTIFICATION, MESSAGE_RECEIVED)
+
+  implicit val notificationTypeWrites: Writes[NotificationType] = (notificationType: NotificationType) => Json.toJson(notificationType.toString)
 
   implicit val notificationTypeReads: Reads[NotificationType] = Reads {
     case JsString("SUBMISSION_NOTIFICATION") => JsSuccess(SUBMISSION_NOTIFICATION)
     case JsString("MESSAGE_RECEIVED")        => JsSuccess(MESSAGE_RECEIVED)
     case _                                   => JsError()
   }
+
+  def findByPathRepresentation(value: String): Option[NotificationType] = values.find(_.pathRepresentation.equalsIgnoreCase(value))
 
 }

--- a/app/uk/gov/hmrc/transitmovementspushnotifications/services/PushPullNotificationService.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/services/PushPullNotificationService.scala
@@ -51,7 +51,8 @@ trait PushPullNotificationService {
     contentLength: Long,
     messageId: MessageId,
     body: Source[ByteString, _],
-    notificationType: NotificationType
+    notificationType: NotificationType,
+    messageType: Option[MessageType]
   )(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier,
@@ -79,7 +80,8 @@ class PushPullNotificationServiceImpl @Inject() (pushPullNotificationConnector: 
     contentLength: Long,
     messageId: MessageId,
     body: Source[ByteString, _],
-    notificationType: NotificationType
+    notificationType: NotificationType,
+    messageType: Option[MessageType]
   )(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier,
@@ -88,29 +90,22 @@ class PushPullNotificationServiceImpl @Inject() (pushPullNotificationConnector: 
 
     lazy val uri = buildUriAsString(boxAssociation._id, messageId, boxAssociation.movementType)
 
-    def selectNotificationType(bodyOpt: Option[String]) =
-      if (NotificationType.SUBMISSION_NOTIFICATION == notificationType)
-        postSubmissionNotification(boxAssociation, uri, bodyOpt)
-      else {
-        postMessageReceivedNotification(boxAssociation, uri, bodyOpt)
-      }
+    def createNotification(body: Option[String]) = notificationType match {
+      case NotificationType.MESSAGE_RECEIVED        => MessageReceivedNotification(uri, messageType, body)
+      case NotificationType.SUBMISSION_NOTIFICATION => SubmissionNotification(uri, body.map(Json.parse))
+    }
 
     EitherT(
       {
-        contentLength match {
-          case 0L => postMessageReceivedNotification(boxAssociation, uri, None)
-          case x if contentLength <= appConfig.maxPushPullPayloadSize =>
-            body
-              .reduce(_ ++ _)
-              .map(_.utf8String)
-              .runWith(Sink.headOption)
-              .flatMap {
-                bodyOpt =>
-                  selectNotificationType(bodyOpt)
-              }
-          case contentLength if contentLength > appConfig.maxPushPullPayloadSize => selectNotificationType(None)
-        }
+        if (contentLength > 0L && contentLength <= appConfig.maxPushPullPayloadSize) {
+          body
+            .reduce(_ ++ _)
+            .map(_.utf8String)
+            .runWith(Sink.headOption)
+        } else Future.successful(None)
       }
+        .map(createNotification)
+        .flatMap(pushPullNotificationConnector.postNotification(boxAssociation.boxId, _))
         .map {
           case Right(_) => Right(())
           case Left(error) =>
@@ -126,24 +121,6 @@ class PushPullNotificationServiceImpl @Inject() (pushPullNotificationConnector: 
         }
     )
   }
-
-  private def postSubmissionNotification(boxAssociation: BoxAssociation, uri: String, body: Option[String])(implicit
-    ec: ExecutionContext,
-    hc: HeaderCarrier
-  ): Future[Either[UpstreamErrorResponse, Unit]] =
-    body match {
-      case Some(body) => pushPullNotificationConnector.postNotification(boxAssociation.boxId, SubmissionNotification(uri, Some(Json.parse(body))))
-      case None       => pushPullNotificationConnector.postNotification(boxAssociation.boxId, SubmissionNotification(uri, None))
-    }
-
-  private def postMessageReceivedNotification(boxAssociation: BoxAssociation, uri: String, body: Option[String])(implicit
-    ec: ExecutionContext,
-    hc: HeaderCarrier
-  ): Future[Either[UpstreamErrorResponse, Unit]] =
-    body match {
-      case Some(body) => pushPullNotificationConnector.postNotification(boxAssociation.boxId, MessageReceivedNotification(uri, Some(body)))
-      case None       => pushPullNotificationConnector.postNotification(boxAssociation.boxId, MessageReceivedNotification(uri, None))
-    }
 
   private def getDefaultBoxId(clientId: String)(implicit ec: ExecutionContext, hc: HeaderCarrier): EitherT[Future, PushPullNotificationError, BoxId] =
     EitherT(

--- a/app/uk/gov/hmrc/transitmovementspushnotifications/services/PushPullNotificationService.scala
+++ b/app/uk/gov/hmrc/transitmovementspushnotifications/services/PushPullNotificationService.scala
@@ -91,8 +91,9 @@ class PushPullNotificationServiceImpl @Inject() (pushPullNotificationConnector: 
     lazy val uri = buildUriAsString(boxAssociation._id, messageId, boxAssociation.movementType)
 
     def createNotification(body: Option[String]) = notificationType match {
-      case NotificationType.MESSAGE_RECEIVED        => MessageReceivedNotification(uri, messageType, body)
-      case NotificationType.SUBMISSION_NOTIFICATION => SubmissionNotification(uri, body.map(Json.parse))
+      case NotificationType.MESSAGE_RECEIVED => MessageReceivedNotification(uri, messageId, boxAssociation._id, boxAssociation.movementType, messageType, body)
+      case NotificationType.SUBMISSION_NOTIFICATION =>
+        SubmissionNotification(uri, messageId, boxAssociation._id, boxAssociation.movementType, body.map(Json.parse))
     }
 
     EitherT(

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val microservice = Project("transit-movements-push-notifications", file("."
     scalacOptions += "-Wconf:src=routes/.*:s",
     // Import models by default in route files
     RoutesKeys.routesImport ++= Seq(
-      "uk.gov.hmrc.transitmovementspushnotifications.models._"
+      "uk.gov.hmrc.transitmovementspushnotifications.models._",
+      "uk.gov.hmrc.transitmovementspushnotifications.models.Bindings._"
     )
   )
   .configs(IntegrationTest)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,9 @@
 # microservice specific routes
 
-POST       /traders/movements/:movementId/box                      uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.createBoxAssociation(movementId: MovementId)
+POST       /traders/movements/:movementId/box                                    uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.createBoxAssociation(movementId: MovementId)
 
-PATCH      /traders/movements/:movementId                          uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.updateAssociationTTL(movementId: MovementId)
+PATCH      /traders/movements/:movementId                                        uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.updateAssociationTTL(movementId: MovementId)
 
-POST       /traders/movements/:movementId/messages/:messageId       uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.postNotification(movementId: MovementId, messageId: MessageId)
+POST       /traders/movements/:movementId/messages/:messageId                    uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.postNotificationByContentType(movementId: MovementId, messageId: MessageId)
+
+POST       /traders/movements/:movementId/messages/:messageId/:notificationType  uk.gov.hmrc.transitmovementspushnotifications.controllers.PushNotificationController.postNotification(movementId: MovementId, messageId: MessageId, notificationType: NotificationType)

--- a/it/uk/gov/hmrc/transitmovementspushnotifications/connectors/PushNotificationConnectorSpec.scala
+++ b/it/uk/gov/hmrc/transitmovementspushnotifications/connectors/PushNotificationConnectorSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.transitmovementspushnotifications.connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
@@ -29,6 +30,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.time.Millis
 import org.scalatest.time.Seconds
 import org.scalatest.time.Span
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.libs.json.Json
 import play.api.test.Helpers.BAD_REQUEST
 import play.api.test.Helpers.FORBIDDEN
@@ -43,13 +45,24 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.transitmovementspushnotifications.config.Constants
 import uk.gov.hmrc.transitmovementspushnotifications.generators.ModelGenerators
+import uk.gov.hmrc.transitmovementspushnotifications.models.BoxId
+import uk.gov.hmrc.transitmovementspushnotifications.models.MessageId
 import uk.gov.hmrc.transitmovementspushnotifications.models.MessageReceivedNotification
+import uk.gov.hmrc.transitmovementspushnotifications.models.MessageType
+import uk.gov.hmrc.transitmovementspushnotifications.models.MovementId
 import uk.gov.hmrc.transitmovementspushnotifications.models.responses.BoxResponse
 import uk.gov.hmrc.transitmovementspushnotifications.utils.GuiceWiremockSuite
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class PushNotificationConnectorSpec extends AnyFreeSpec with Matchers with ScalaFutures with GuiceWiremockSuite with ModelGenerators with OptionValues {
+class PushNotificationConnectorSpec
+    extends AnyFreeSpec
+    with Matchers
+    with ScalaFutures
+    with GuiceWiremockSuite
+    with ModelGenerators
+    with OptionValues
+    with ScalaCheckDrivenPropertyChecks {
   override protected def portConfigKey: Seq[String] = Seq("microservice.services.push-pull-notifications-api.port")
 
   implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
@@ -225,75 +238,112 @@ class PushNotificationConnectorSpec extends AnyFreeSpec with Matchers with Scala
 
     "postNotification" - {
 
-      val boxId        = arbitraryBoxId.arbitrary.sample.value
-      val validPayload = """{"message":"<CC007C>data</CC007C>"}"""
-
-      val messageNotificationWithBody = MessageReceivedNotification(
-        messageUri = "/customs/transits/movements/departures/movement-id-1/messages/message-id-1",
-        messageBody = Some(validPayload)
-      )
-
-      val messageNotificationWithoutBody = MessageReceivedNotification(
-        messageUri = "/customs/transits/movements/departures/movement-id-1/messages/message-id-1",
-        messageBody = None
-      )
-
       "when called with a valid message notification with a body and box id that is in the database" - {
-        "should return Unit () when the post is successful" in {
-          server.stubFor {
-            post(urlPathEqualTo(s"/box/${boxId.value}/notifications")).willReturn(
-              aResponse()
-                .withStatus(OK)
+        "should return Unit () when the post is successful" in forAll(
+          arbitrary[BoxId],
+          arbitrary[MessageId],
+          arbitrary[MovementId],
+          Gen.alphaNumStr,
+          arbitrary[MessageType]
+        ) {
+          (boxId, messageId, movementId, body, messageType) =>
+            val messageNotificationWithBody = MessageReceivedNotification(
+              messageUri = s"/customs/transits/movements/departures/${movementId.value}/messages/${messageId.value}",
+              messageBody = Some(body),
+              messageType = Some(messageType)
             )
-          }
-
-          val app = applicationBuilder.build()
-          running(app) {
-            val connector = app.injector.instanceOf[PushPullNotificationConnector]
-            whenReady(connector.postNotification(boxId, messageNotificationWithBody)) {
-              _ mustEqual Right(())
-            }
-          }
-        }
-      }
-
-      "when called with a valid message notification with no body and box id that is in the database" - {
-        "should return Unit () when the post is successful" in {
-          server.stubFor {
-            post(urlPathEqualTo(s"/box/${boxId.value}/notifications")).willReturn(
-              aResponse()
-                .withStatus(OK)
-            )
-          }
-
-          val app = applicationBuilder.build()
-          running(app) {
-            val connector = app.injector.instanceOf[PushPullNotificationConnector]
-            whenReady(connector.postNotification(boxId, messageNotificationWithoutBody)) {
-              _ mustEqual Right(())
-            }
-          }
-        }
-      }
-
-      for (error <- List(BAD_REQUEST, FORBIDDEN, NOT_FOUND, REQUEST_ENTITY_TOO_LARGE))
-        "when called with an invalid request" - {
-          s"should return error an error response: $error" in {
             server.stubFor {
-              post(urlPathEqualTo(s"/box/${boxId.value}/notifications")).willReturn(
-                aResponse()
-                  .withStatus(error)
-              )
+              post(urlPathEqualTo(s"/box/${boxId.value}/notifications"))
+                .withRequestBody(
+                  equalToJson(
+                    s"""
+                    |{
+                    |   "messageUri": "/customs/transits/movements/departures/${movementId.value}/messages/${messageId.value}",
+                    |   "notificationType": "MESSAGE_RECEIVED",
+                    |   "messageBody": "$body",
+                    |   "messageType": "${messageType.value}"
+                    |}
+                    |""".stripMargin
+                  )
+                )
+                .willReturn(
+                  aResponse()
+                    .withStatus(OK)
+                )
             }
 
             val app = applicationBuilder.build()
             running(app) {
               val connector = app.injector.instanceOf[PushPullNotificationConnector]
               whenReady(connector.postNotification(boxId, messageNotificationWithBody)) {
-                case Left(value)  => value.statusCode mustEqual error
-                case Right(value) => fail(s"There must not be a Right (got $value instead)")
+                _ mustEqual Right((): Unit)
               }
             }
+        }
+      }
+
+      "when called with a valid message notification with no body and box id that is in the database" - {
+        "should return Unit () when the post is successful" in forAll(arbitrary[BoxId], arbitrary[MessageId], arbitrary[MovementId], arbitrary[MessageType]) {
+          (boxId, messageId, movementId, messageType) =>
+            val messageNotificationWithoutBody = MessageReceivedNotification(
+              messageUri = s"/customs/transits/movements/departures/${movementId.value}/messages/${messageId.value}",
+              messageBody = None,
+              messageType = Some(messageType)
+            )
+            server.stubFor {
+              post(urlPathEqualTo(s"/box/${boxId.value}/notifications"))
+                .withRequestBody(
+                  equalToJson(
+                    s"""
+                     |{
+                     |   "messageUri": "/customs/transits/movements/departures/${movementId.value}/messages/${messageId.value}",
+                     |   "notificationType": "MESSAGE_RECEIVED",
+                     |   "messageType": "${messageType.value}"
+                     |}
+                     |""".stripMargin
+                  )
+                )
+                .willReturn(
+                  aResponse()
+                    .withStatus(OK)
+                )
+            }
+
+            val app = applicationBuilder.build()
+            running(app) {
+              val connector = app.injector.instanceOf[PushPullNotificationConnector]
+              whenReady(connector.postNotification(boxId, messageNotificationWithoutBody)) {
+                _ mustEqual Right((): Unit)
+              }
+            }
+        }
+      }
+
+      for (error <- List(BAD_REQUEST, FORBIDDEN, NOT_FOUND, REQUEST_ENTITY_TOO_LARGE))
+        "when called with an invalid request" - {
+          s"should return error an error response: $error" in forAll(arbitrary[BoxId], arbitrary[MessageId], arbitrary[MovementId], arbitrary[MessageType]) {
+            (boxId, messageId, movementId, messageType) =>
+              val messageNotificationWithoutBody = MessageReceivedNotification(
+                messageUri = s"/customs/transits/movements/departures/$movementId/messages/$messageId",
+                messageBody = None,
+                messageType = Some(messageType)
+              )
+
+              server.stubFor {
+                post(urlPathEqualTo(s"/box/${boxId.value}/notifications")).willReturn(
+                  aResponse()
+                    .withStatus(error)
+                )
+              }
+
+              val app = applicationBuilder.build()
+              running(app) {
+                val connector = app.injector.instanceOf[PushPullNotificationConnector]
+                whenReady(connector.postNotification(boxId, messageNotificationWithoutBody)) {
+                  case Left(value)  => value.statusCode mustEqual error
+                  case Right(value) => fail(s"There must not be a Right (got $value instead)")
+                }
+              }
           }
         }
     }

--- a/it/uk/gov/hmrc/transitmovementspushnotifications/generators/ModelGenerators.scala
+++ b/it/uk/gov/hmrc/transitmovementspushnotifications/generators/ModelGenerators.scala
@@ -39,13 +39,23 @@ trait ModelGenerators extends BaseGenerators {
         )
     }
 
-  lazy val arbitraryMessageId: Arbitrary[MessageId] =
+  implicit lazy val arbitraryMessageId: Arbitrary[MessageId] =
     Arbitrary {
       Gen
         .listOfN(16, Gen.hexChar)
         .map(
           id => MessageId(id.mkString)
         )
+    }
+
+  implicit lazy val arbitraryMessageType: Arbitrary[MessageType] =
+    Arbitrary {
+      Gen.stringOfN(5, Gen.alphaNumChar).map(MessageType.apply)
+    }
+
+  implicit lazy val arbitraryOptionalMessageType: Arbitrary[Option[MessageType]] =
+    Arbitrary {
+      Gen.option(arbitrary[MessageType])
     }
 
   implicit lazy val arbitraryBoxId: Arbitrary[BoxId] = Arbitrary {

--- a/test/uk/gov/hmrc/transitmovementspushnotifications/generators/ModelGenerators.scala
+++ b/test/uk/gov/hmrc/transitmovementspushnotifications/generators/ModelGenerators.scala
@@ -22,6 +22,7 @@ import org.scalacheck.Gen
 import uk.gov.hmrc.transitmovementspushnotifications.models.BoxAssociation
 import uk.gov.hmrc.transitmovementspushnotifications.models.BoxId
 import uk.gov.hmrc.transitmovementspushnotifications.models.MessageId
+import uk.gov.hmrc.transitmovementspushnotifications.models.MessageType
 import uk.gov.hmrc.transitmovementspushnotifications.models.MovementId
 import uk.gov.hmrc.transitmovementspushnotifications.models.MovementType
 import uk.gov.hmrc.transitmovementspushnotifications.models.NotificationType
@@ -51,6 +52,11 @@ trait ModelGenerators extends BaseGenerators {
         .map(
           id => MessageId(id.mkString)
         )
+    }
+
+  implicit lazy val arbitraryMessageType: Arbitrary[MessageType] =
+    Arbitrary {
+      Gen.stringOfN(5, Gen.alphaNumChar).map(MessageType.apply)
     }
 
   implicit lazy val arbitraryBoxId: Arbitrary[BoxId] = Arbitrary {

--- a/test/uk/gov/hmrc/transitmovementspushnotifications/models/BindingsSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementspushnotifications/models/BindingsSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.transitmovementspushnotifications.models
+
+import org.scalacheck.Gen
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+class BindingsSpec extends AnyFreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+
+  "notificationTypeBinding" - {
+    "bind" - {
+      "when the specified type exists" in forAll(Gen.oneOf(NotificationType.values)) {
+        notificationType =>
+          Bindings.notificationTypeBinding.bind("ignored", notificationType.pathRepresentation) mustBe Right(notificationType)
+      }
+
+      "when the specified type does not exist" in forAll(Gen.stringOfN(2, Gen.alphaChar)) {
+        notificationType =>
+          Bindings.notificationTypeBinding.bind("ignored", notificationType) mustBe Left(s"Unable to find notification type of $notificationType")
+      }
+    }
+
+    "unbind return the path representation" in forAll(Gen.oneOf(NotificationType.values)) {
+      notificationType =>
+        Bindings.notificationTypeBinding.unbind("ignored", notificationType) mustBe notificationType.pathRepresentation
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/transitmovementspushnotifications/services/PushNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementspushnotifications/services/PushNotificationServiceSpec.scala
@@ -161,9 +161,10 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
       "should return a valid response" in forAll(
         arbitrary[BoxAssociation],
         arbitrary[MessageId],
-        arbitrary[NotificationType]
+        arbitrary[NotificationType],
+        Gen.option(arbitrary[MessageType])
       ) {
-        (boxAssociation, messageId, notificationType) =>
+        (boxAssociation, messageId, notificationType, messageTypeMaybe) =>
           when(mockAppConfig.maxPushPullPayloadSize).thenReturn(maxPayloadSize)
 
           val (notification, source) = {
@@ -171,6 +172,7 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageTypeMaybe,
                   Some(sampleString)
                 ),
                 Source.single(ByteString(sampleString, StandardCharsets.UTF_8))
@@ -199,7 +201,8 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
             contentLength = maxPayloadSize - 1,
             messageId = messageId,
             body = source,
-            notificationType
+            notificationType,
+            messageTypeMaybe
           )
 
           whenReady(result.value) {
@@ -212,9 +215,10 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
       "should return a valid response" in forAll(
         arbitrary[BoxAssociation],
         arbitrary[MessageId],
-        arbitrary[NotificationType]
+        arbitrary[NotificationType],
+        Gen.option(arbitrary[MessageType])
       ) {
-        (boxAssociation, messageId, notificationType) =>
+        (boxAssociation, messageId, notificationType, messageTypeMaybe) =>
           when(mockAppConfig.maxPushPullPayloadSize).thenReturn(maxPayloadSize)
 
           val (notification, source) = {
@@ -222,6 +226,7 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageTypeMaybe,
                   None
                 ),
                 Source.single(ByteString(sampleString, StandardCharsets.UTF_8))
@@ -250,7 +255,8 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
             contentLength = maxPayloadSize + 1,
             messageId = messageId,
             body = source,
-            notificationType
+            notificationType,
+            messageTypeMaybe
           )
 
           whenReady(result.value) {
@@ -262,12 +268,14 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
     "when given a valid boxId without payload" - {
       "should return a valid response" in forAll(
         arbitrary[BoxAssociation],
-        arbitrary[MessageId]
+        arbitrary[MessageId],
+        Gen.option(arbitrary[MessageType])
       ) {
-        (boxAssociation, messageId) =>
+        (boxAssociation, messageId, messageTypeMaybe) =>
           val expectedMessageNotification =
             MessageReceivedNotification(
               s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+              messageTypeMaybe,
               None
             )
 
@@ -282,7 +290,8 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
             contentLength = 0L,
             messageId = messageId,
             body = Source.single(ByteString("", StandardCharsets.UTF_8)),
-            NotificationType.MESSAGE_RECEIVED
+            NotificationType.MESSAGE_RECEIVED,
+            messageTypeMaybe
           )
 
           whenReady(result.value) {
@@ -295,14 +304,16 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
       "should return a not found response" in forAll(
         arbitrary[BoxAssociation],
         arbitrary[MessageId],
-        arbitrary[NotificationType]
+        arbitrary[NotificationType],
+        Gen.option(arbitrary[MessageType])
       ) {
-        (boxAssociation, messageId, notificationType) =>
+        (boxAssociation, messageId, notificationType, messageTypeMaybe) =>
           val (notification, source) = {
             if (notificationType == NotificationType.MESSAGE_RECEIVED) {
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageTypeMaybe,
                   Some(sampleString)
                 ),
                 Source.single(ByteString(sampleString, StandardCharsets.UTF_8))
@@ -330,7 +341,8 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
             contentLength = maxPayloadSize - 1,
             messageId = messageId,
             body = source,
-            notificationType
+            notificationType,
+            messageTypeMaybe
           )
 
           whenReady(result.value) {
@@ -343,14 +355,16 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
       "should return a response indicating an unexpected error occurred" in forAll(
         arbitrary[BoxAssociation],
         arbitrary[MessageId],
-        arbitrary[NotificationType]
+        arbitrary[NotificationType],
+        Gen.option(arbitrary[MessageType])
       ) {
-        (boxAssociation, messageId, notificationType) =>
+        (boxAssociation, messageId, notificationType, messageTypeMaybe) =>
           val (notification, source) = {
             if (notificationType == NotificationType.MESSAGE_RECEIVED) {
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageTypeMaybe,
                   Some(sampleString)
                 ),
                 Source.single(ByteString(sampleString, StandardCharsets.UTF_8))
@@ -378,7 +392,8 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
             contentLength = maxPayloadSize - 1,
             messageId = messageId,
             body = source,
-            notificationType
+            notificationType,
+            messageTypeMaybe
           )
 
           whenReady(result.value) {

--- a/test/uk/gov/hmrc/transitmovementspushnotifications/services/PushNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/transitmovementspushnotifications/services/PushNotificationServiceSpec.scala
@@ -172,6 +172,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   messageTypeMaybe,
                   Some(sampleString)
                 ),
@@ -182,6 +185,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 SubmissionNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   Some(validJSONBody)
                 ),
                 Source.single(ByteString(Json.stringify(validJSONBody), StandardCharsets.UTF_8))
@@ -226,6 +232,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   messageTypeMaybe,
                   None
                 ),
@@ -236,6 +245,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 SubmissionNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   None
                 ),
                 Source.single(ByteString(Json.stringify(validJSONBody), StandardCharsets.UTF_8))
@@ -275,6 +287,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
           val expectedMessageNotification =
             MessageReceivedNotification(
               s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+              messageId,
+              boxAssociation._id,
+              boxAssociation.movementType,
               messageTypeMaybe,
               None
             )
@@ -313,6 +328,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   messageTypeMaybe,
                   Some(sampleString)
                 ),
@@ -323,6 +341,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 SubmissionNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   Some(validJSONBody)
                 ),
                 Source.single(ByteString(Json.stringify(validJSONBody), StandardCharsets.UTF_8))
@@ -364,6 +385,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 MessageReceivedNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   messageTypeMaybe,
                   Some(sampleString)
                 ),
@@ -374,6 +398,9 @@ class PushNotificationServiceSpec extends SpecBase with ModelGenerators with Tes
               (
                 SubmissionNotification(
                   s"/customs/transits/movements/${boxAssociation.movementType.urlFragment}/${boxAssociation._id.value}/messages/${messageId.value}",
+                  messageId,
+                  boxAssociation._id,
+                  boxAssociation.movementType,
                   Some(validJSONBody)
                 ),
                 Source.single(ByteString(Json.stringify(validJSONBody), StandardCharsets.UTF_8))


### PR DESCRIPTION
Also created new route to include notification type in the path, though left the old one in for the moment so we can migrate other services over time if necessary.