### PR TITLE
Upgrade libraries: sbt-plugin → 3.0.10, bootstrap-backend-play-30 → 10.6.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "10.5.0"
+  private val bootstrapPlayVersion = "10.6.0"
   private val catsVersion          = "2.13.0"
   private val mongoPlay            = "2.12.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.9")
+addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.10")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.2.2")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.5")


### PR DESCRIPTION
## Library Upgrades

| Group | Artifact | New Version |
|-------|----------|-------------|
| `org.playframework` | `sbt-plugin` | `3.0.10` |
| `uk.gov.hmrc` | `bootstrap-backend-play-30` | `10.6.0` |

_This PR was created automatically by the Library Upgrade Tool._